### PR TITLE
Suggested improvements to checklibs.py script

### DIFF
--- a/checklibs.py
+++ b/checklibs.py
@@ -209,7 +209,7 @@ class MachOFile:
     @classmethod
     def architectures_for_image_at_path(cls, path):
         output = cls.shell('file "{}"', [path])
-        file_architectures = re.findall(r' executable (\w+)', output)
+        file_architectures = re.findall(r'\[(\w+):Mach-O ', output)
         ordering = 'x86_64 i386'.split()
         file_architectures = sorted(file_architectures, lambda a, b: cmp(ordering.index(a), ordering.index(b)))
         return file_architectures

--- a/checklibs.py
+++ b/checklibs.py
@@ -302,12 +302,12 @@ if len(args) < 1:
     parser.print_help()
     sys.exit(1)
 
-archs = MachOFile.architectures_for_image_at_path(args[0])
+archs = MachOFile.architectures_for_image_at_path(os.path.abspath(args[0]))
 if archs and not options.arch:
     print >> sys.stderr, 'Analyzing architecture {}, override with --arch if needed'.format(archs[0])
     options.arch = archs[0]
 
-toplevel_image = MachOFile(ImagePath(args[0]), options.arch)
+toplevel_image = MachOFile(ImagePath(os.path.abspath(args[0])), options.arch)
 
 for dependency in toplevel_image.all_dependencies():
     if dependency.image_path.exists() and (not options.include_system_libraries) and dependency.image_path.is_system_location():


### PR DESCRIPTION
Handle output from either /usr/bin/file or MacPorts file 5.32 (order of output has changed between magic versions).
Use os.path.abspath() to determine executable's absolute path to enable absolute path output for found libraries when a relative path is given on the command line.
Add --verbose flag to enable diagnostics from the code that checks various path substitutions.
